### PR TITLE
Switch prepDetections to gsub.

### DIFF
--- a/R/prepFiles.R
+++ b/R/prepFiles.R
@@ -8,25 +8,32 @@
 #' }
 prepDetections <- function(raw_dat, type){
   
-	detections <- data.table::copy(raw_dat)
-	
-	if (type == "vemco_vue"){
-	  
-	  # Only parse datetime if needed
-	  if(!inherits(detections$`Date and Time (UTC)`, 'POSIXt')){
-	    detections[, ts := as.POSIXct(`Date and Time (UTC)`, tz = "UTC")]
-	  } else{
-	    detections[, ts := `Date and Time (UTC)`]
-	  }
-	  
-	  
-	  detections[, ':='(tag = as.numeric(gsub('.*-', '', Transmitter)),
-	                    epo = as.numeric(ts),
-	                    serial = as.numeric(gsub('.*-', '', Receiver)))]
-	  detections[, frac := epo - floor(epo),]
-	}
-	
-	detections[, .(ts, tag, epo, frac, serial)]
+  detections <- data.table::copy(raw_dat)
+  
+  if (type == "vemco_vue"){
+    
+    # Only parse datetime if needed
+    if(!inherits(detections$`Date and Time (UTC)`, 'POSIXt')){
+      detections[, ts := as.POSIXct(`Date and Time (UTC)`,
+                                    format = '%Y-%m-%d %H:%M:%OS',
+                                    tz = 'UTC')]
+    } else{
+      detections[, ts := `Date and Time (UTC)`]
+    }
+    
+    
+    detections[, ':='(tag = as.numeric(gsub('.*-', '', Transmitter)),
+                      serial = as.numeric(gsub('.*-', '', Receiver)),
+                      epo = as.numeric(ts))]
+    detections[, frac := round(epo - floor(epo), 3)]
+    detections[, epo := floor(epo)]
+    detections[, ts := as.POSIXct(epo, 
+                                  origin = '1970-01-01',
+                                  tz = 'UTC')]
+    
+  }
+  
+  detections[, .(ts, tag, epo, frac, serial)]
 	
 }
 	

--- a/R/prepFiles.R
+++ b/R/prepFiles.R
@@ -9,11 +9,12 @@
 prepDetections <- function(raw_dat, type){
 	detections <- data.table::data.table()
 	if (type == "vemco_vue"){
-		detections[, ts:=as.POSIXct(raw_dat$'Date and Time (UTC)', tz="UTC")]
-		detections[, tag:=as.numeric(sapply(raw_dat$Transmitter, function(x) strsplit(x, "-")[[1]][3]))]
-		detections[, epo:=as.numeric(ts)]
-		detections[, frac:= (as.numeric(sapply(raw_dat$'Date and Time (UTC)', function(x) strsplit(x, "\\.")[[1]][2]))) / 1000]
-		detections[, serial:=as.numeric(sapply(raw_dat$Receiver, function(x) strsplit(x, "-")[[1]][2]))]
+	  detections[, ts := as.POSIXct(raw_dat$'Date and Time (UTC)', tz = "UTC")]
+	  detections[, tag := as.numeric(gsub('.*-', '', raw_dat$Transmitter))]
+	  detections[, epo := as.numeric(ts)]
+	  detections[, frac := as.numeric(gsub('.*\\.', '',
+	                                       raw_dat$"Date and Time (UTC)")) / 1000]
+	  detections[, serial := as.numeric(gsub('.*-', '', raw_dat$Receiver))]
 	}
 	detections[]
 	return(detections)

--- a/R/prepFiles.R
+++ b/R/prepFiles.R
@@ -8,45 +8,22 @@
 #' }
 prepDetections <- function(raw_dat, type){
   
-  # gsub (and the previous version using strsplit) convert to character before
-  #   doing their thing. The default number of millisecond digits for R to
-  #   display is 0, so millisecond information is dropped when converted to
-  #   character. Temporarily change this to keep milliseconds, then used on.exit
-  #   to change the option back to what it was before when the function finishes
-  op <- options(digits.secs = 3)
-  on.exit(options(op), add = T)
-  
 	detections <- data.table::copy(raw_dat)
 	
 	if (type == "vemco_vue"){
 	  
 	  # Only parse datetime if needed
-	  ##  trunc drops milliseconds but converts to POSIXlt in the process, so it needs
-	  ##  to be converted back to POSIXct for use elsewhere.
-	  
 	  if(!inherits(detections$`Date and Time (UTC)`, 'POSIXt')){
-	    
-	    detections[, ts :=
-	                 as.POSIXct(
-	                   trunc(
-	                     as.POSIXct(`Date and Time (UTC)`, tz = "UTC")
-	                   )
-	                 )]
-	    
+	    detections[, ts := as.POSIXct(`Date and Time (UTC)`, tz = "UTC")]
 	  } else{
-	    
-	    detections[, ts :=
-	                 as.POSIXct(
-	                   trunc(`Date and Time (UTC)`)
-	                 )]
-	    
+	    detections[, ts := `Date and Time (UTC)`]
 	  }
+	  
 	  
 	  detections[, ':='(tag = as.numeric(gsub('.*-', '', Transmitter)),
 	                    epo = as.numeric(ts),
-	                    frac = as.numeric(gsub('.*\\.', '',
-	                                            `Date and Time (UTC)`)) / 1000,
 	                    serial = as.numeric(gsub('.*-', '', Receiver)))]
+	  detections[, frac := epo - floor(epo),]
 	}
 	
 	detections[, .(ts, tag, epo, frac, serial)]

--- a/R/prepFiles.R
+++ b/R/prepFiles.R
@@ -7,16 +7,49 @@
 #' prepped_detections <- prepDetections("path-to-raw-data-file", type="vemco_vue")
 #' }
 prepDetections <- function(raw_dat, type){
-	detections <- data.table::data.table()
+  
+  # gsub (and the previous version using strsplit) convert to character before
+  #   doing their thing. The default number of millisecond digits for R to
+  #   display is 0, so millisecond information is dropped when converted to
+  #   character. Temporarily change this to keep milliseconds, then used on.exit
+  #   to change the option back to what it was before when the function finishes
+  op <- options(digits.secs = 3)
+  on.exit(options(op), add = T)
+  
+	detections <- data.table::copy(raw_dat)
+	
 	if (type == "vemco_vue"){
-	  detections[, ts := as.POSIXct(raw_dat$'Date and Time (UTC)', tz = "UTC")]
-	  detections[, tag := as.numeric(gsub('.*-', '', raw_dat$Transmitter))]
-	  detections[, epo := as.numeric(ts)]
-	  detections[, frac := as.numeric(gsub('.*\\.', '',
-	                                       raw_dat$"Date and Time (UTC)")) / 1000]
-	  detections[, serial := as.numeric(gsub('.*-', '', raw_dat$Receiver))]
+	  
+	  # Only parse datetime if needed
+	  ##  trunc drops milliseconds but converts to POSIXlt in the process, so it needs
+	  ##  to be converted back to POSIXct for use elsewhere.
+	  
+	  if(!inherits(detections$`Date and Time (UTC)`, 'POSIXt')){
+	    
+	    detections[, ts :=
+	                 as.POSIXct(
+	                   trunc(
+	                     as.POSIXct(`Date and Time (UTC)`, tz = "UTC")
+	                   )
+	                 )]
+	    
+	  } else{
+	    
+	    detections[, ts :=
+	                 as.POSIXct(
+	                   trunc(`Date and Time (UTC)`)
+	                 )]
+	    
+	  }
+	  
+	  detections[, ':='(tag = as.numeric(gsub('.*-', '', Transmitter)),
+	                    epo = as.numeric(ts),
+	                    frac = as.numeric(gsub('.*\\.', '',
+	                                            `Date and Time (UTC)`)) / 1000,
+	                    serial = as.numeric(gsub('.*-', '', Receiver)))]
 	}
-	detections[]
-	return(detections)
+	
+	detections[, .(ts, tag, epo, frac, serial)]
+	
 }
 	


### PR DESCRIPTION
Allows speed increase outlined in #38.

Note: will give the error 

> Warning message: In eval(jsub, SDenv, parent.frame()) : NAs introduced by coercion

when a match doesn't occurr. This happened for me on a few lines where fractional seconds weren't reported for some reason.