### PR TITLE
Switch prepDetections to gsub. (#39)

### DIFF
--- a/R/prepFiles.R
+++ b/R/prepFiles.R
@@ -7,15 +7,33 @@
 #' prepped_detections <- prepDetections("path-to-raw-data-file", type="vemco_vue")
 #' }
 prepDetections <- function(raw_dat, type){
-	detections <- data.table::data.table()
-	if (type == "vemco_vue"){
-		detections[, ts:=as.POSIXct(raw_dat$'Date and Time (UTC)', tz="UTC")]
-		detections[, tag:=as.numeric(sapply(raw_dat$Transmitter, function(x) strsplit(x, "-")[[1]][3]))]
-		detections[, epo:=as.numeric(ts)]
-		detections[, frac:= (as.numeric(sapply(raw_dat$'Date and Time (UTC)', function(x) strsplit(x, "\\.")[[1]][2]))) / 1000]
-		detections[, serial:=as.numeric(sapply(raw_dat$Receiver, function(x) strsplit(x, "-")[[1]][2]))]
-	}
-	detections[]
-	return(detections)
+  
+  detections <- data.table::copy(raw_dat)
+  
+  if (type == "vemco_vue"){
+    
+    # Only parse datetime if needed
+    if(!inherits(detections$`Date and Time (UTC)`, 'POSIXt')){
+      detections[, ts := as.POSIXct(`Date and Time (UTC)`,
+                                    format = '%Y-%m-%d %H:%M:%OS',
+                                    tz = 'UTC')]
+    } else{
+      detections[, ts := `Date and Time (UTC)`]
+    }
+    
+    
+    detections[, ':='(tag = as.numeric(gsub('.*-', '', Transmitter)),
+                      serial = as.numeric(gsub('.*-', '', Receiver)),
+                      epo = as.numeric(ts))]
+    detections[, frac := round(epo - floor(epo), 3)]
+    detections[, epo := floor(epo)]
+    detections[, ts := as.POSIXct(epo, 
+                                  origin = '1970-01-01',
+                                  tz = 'UTC')]
+    
+  }
+  
+  detections[, .(ts, tag, epo, frac, serial)]
+	
 }
 	


### PR DESCRIPTION
* Switch to gsub.

* Change options() to keep millisecond information. Copy raw data and change by reference.

* Change frac calculation and drop resulting excess.

* Explicity provide date format. Round off ts, epo, and frac.